### PR TITLE
chore: update Read the Docs configuration for documentation build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,3 +1,13 @@
+version: 2
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+sphinx:
+  configuration: docs/conf.py
+python:
+  install:
+    - requirements: docs/requirements.txt
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 


### PR DESCRIPTION
- Updated the Read the Docs configuration file to version 2, specifying the build environment as Ubuntu 22.04 and Python 3.12.
- Added Sphinx configuration pointing to docs/conf.py and included installation requirements from docs/requirements.txt, ensuring proper setup for documentation generation.