### PR TITLE
chore: refine Read the Docs configuration for documentation build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,13 +1,3 @@
-version: 2
-build:
-  os: ubuntu-22.04
-  tools:
-    python: "3.12"
-sphinx:
-  configuration: docs/conf.py
-python:
-  install:
-    - requirements: docs/requirements.txt
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -40,6 +30,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - requirements: docs/requirements.txt
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
- Removed unnecessary build environment specifications and streamlined the configuration for Read the Docs.
- Ensured that the installation requirements from docs/requirements.txt are correctly included, maintaining proper setup for documentation generation.