### PR TITLE
feat(capcmd): differentiate tee and ttee in pipeline detection (#162)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 `Unreleased`_
 =============
+- capcmd: differentiate ``tee`` and ``ttee`` in pipeline detection. Plain ``cmd | tee out`` now commits ``out`` as a transparent passthrough -- the file is no longer mutated. ``cmd | ttee out`` (using the trops-aliased ``ttee`` defined in ``trops init``) commits the file *and* prepends ``# <left-command>`` as the first line, so that the originating command is recorded inside the artifact. ``-a`` / ``--append`` skips the prepend so that growing log files are not silently rewritten. **Backward-compat note**: anyone whose current workflow relied on ``tee`` implicitly prepending ``# <cmd>`` should switch to ``ttee``; existing files in the env git repo are unaffected. (#162)
 - perf: cut ``capture-cmd`` baseline overhead by lazy-loading subcommand modules in ``exec.py`` (only the invoked subcommand is imported) and deferring ``subprocess`` / ``re`` imports in ``capcmd.py`` to the editor / tee / package paths that actually need them. Trivial-command import chain drops ~146ms → ~64ms cumulative; user CPU per prompt drops ~50ms → ~30ms (#166).
 - capcmd: skip ``tmp/`` ``mkdir`` when the directory already exists; fast-skip the tee-pipeline tokenizer when no ``|`` is in the command; remove the dead duplicated ``_sanitize_for_sudo`` block.
 

--- a/src/trops/capcmd.py
+++ b/src/trops/capcmd.py
@@ -276,9 +276,15 @@ class TropsCapCmd(TropsBase):
             self._add_file_in_git_repo(executed_cmd, 1)
 
     def _add_tee_output_file(self, executed_cmd: List[str]) -> bool:
-        """Detect tee after one or more pipes and add the target file(s).
+        """Detect tee/ttee after one or more pipes and add the target file(s).
 
-        Supported forms:
+        Plain ``tee`` commits the file as-is. ``ttee`` (an alias for ``tee``
+        declared in ``trops init``) additionally prepends ``# <left-command>``
+        as the first line of the file, unless ``-a/--append`` is among the
+        args after ``ttee`` (in append mode the prepend would silently rewrite
+        the head of an unrelated growing log).
+
+        Supported forms (same with ``ttee`` in place of ``tee``):
           - cmd | tee path/to/file
           - cmd |tee path/to/file
           - cmd1 | cmd2 | ... | tee path/to/file
@@ -297,22 +303,29 @@ class TropsCapCmd(TropsBase):
             else:
                 normalized.append(tok)
 
-        # Scan for the last occurrence of '|' followed by 'tee'
+        # Scan for the last occurrence of '|' followed by 'tee' or 'ttee'
         last_pipe_index = -1
+        tee_word = None
         for i in range(len(normalized) - 1):
-            if normalized[i] == '|' and normalized[i + 1] == 'tee':
-                last_pipe_index = i  # index of '|' just before tee
+            if normalized[i] == '|' and normalized[i + 1] in ('tee', 'ttee'):
+                last_pipe_index = i  # index of '|' just before tee/ttee
+                tee_word = normalized[i + 1]
 
-        if last_pipe_index != -1:
-            # Determine the left-hand command (before the last pipe that precedes tee)
-            left_cmd_tokens = normalized[:last_pipe_index]
-            left_cmd = ' '.join(left_cmd_tokens).strip()
+        if last_pipe_index == -1:
+            return False
+
+        tee_index = last_pipe_index + 1  # 'tee' or 'ttee'
+        args_after_tee = normalized[tee_index + 1:]
+        is_append = '-a' in args_after_tee or '--append' in args_after_tee
+
+        if tee_word == 'ttee' and not is_append:
+            left_cmd = ' '.join(normalized[:last_pipe_index]).strip()
             comment = f"# {left_cmd}" if left_cmd else None
-            # Start collecting path arguments after 'tee'
-            tee_index = last_pipe_index + 1  # 'tee'
-            self._add_file_in_git_repo(normalized, tee_index + 1, first_line_comment=comment)
-            return True
-        return False
+        else:
+            comment = None
+
+        self._add_file_in_git_repo(normalized, tee_index + 1, first_line_comment=comment)
+        return True
 
     def _sanitize_for_sudo(self, executed_cmd: List[str]) -> List[str]:
         """Remove leading sudo if present. TODO: handle sudo options."""

--- a/tests/test_capcmd.py
+++ b/tests/test_capcmd.py
@@ -270,3 +270,119 @@ def test_editor_file_log_is_deferred_until_after_command(monkeypatch, tmp_path, 
 
 	# Verify ordering: command log should appear before file log
 	assert cm_indices[0] < fl_indices[0], f"Expected CM before FL; got order: {[(i, messages[i]) for i in (cm_indices[0], fl_indices[0])]}"
+
+
+def _make_capcmd(monkeypatch, tmp_path):
+	"""Build a TropsCapCmd instance with TROPS_DIR set and no env, for unit tests."""
+	trops_dir = tmp_path / 'trops'
+	trops_dir.mkdir(parents=True, exist_ok=True)
+	monkeypatch.setenv("TROPS_DIR", str(trops_dir))
+	with patch("sys.argv", ["trops", "capture-cmd", '0', "echo", "hi"]):
+		parser = argparse.ArgumentParser(prog='trops', description='Trops - Tracking Operations')
+		subparsers = parser.add_subparsers()
+		add_capture_cmd_subparsers(subparsers)
+		args, other_args = parser.parse_known_args()
+	return TropsCapCmd(args, other_args)
+
+
+def test_tee_does_not_prepend_comment(monkeypatch, tmp_path):
+	"""Plain `cmd | tee path` is detected and the file is committed without a comment prepend (#162)."""
+	captured = {}
+
+	def fake_add(self, executed_cmd, start_index, first_line_comment=None):
+		captured['paths'] = executed_cmd[start_index:]
+		captured['first_line_comment'] = first_line_comment
+
+	monkeypatch.setattr(TropsCapCmd, '_add_file_in_git_repo', fake_add, raising=True)
+
+	tcc = _make_capcmd(monkeypatch, tmp_path)
+	rv = tcc._add_tee_output_file(['echo', 'hi', '|', 'tee', '/tmp/out.txt'])
+
+	assert rv is True
+	assert captured['paths'] == ['/tmp/out.txt']
+	assert captured['first_line_comment'] is None
+
+
+def test_ttee_prepends_left_command(monkeypatch, tmp_path):
+	"""`cmd | ttee path` is detected; `# <left-cmd>` is passed as first_line_comment (#162)."""
+	captured = {}
+
+	def fake_add(self, executed_cmd, start_index, first_line_comment=None):
+		captured['paths'] = executed_cmd[start_index:]
+		captured['first_line_comment'] = first_line_comment
+
+	monkeypatch.setattr(TropsCapCmd, '_add_file_in_git_repo', fake_add, raising=True)
+
+	tcc = _make_capcmd(monkeypatch, tmp_path)
+	rv = tcc._add_tee_output_file(['echo', 'hi', '|', 'ttee', '/tmp/out.txt'])
+
+	assert rv is True
+	assert captured['paths'] == ['/tmp/out.txt']
+	assert captured['first_line_comment'] == '# echo hi'
+
+
+def test_ttee_with_short_append_skips_prepend(monkeypatch, tmp_path):
+	"""`cmd | ttee -a path` skips the prepend (append mode) but still commits the file (#162)."""
+	captured = {}
+
+	def fake_add(self, executed_cmd, start_index, first_line_comment=None):
+		captured['first_line_comment'] = first_line_comment
+
+	monkeypatch.setattr(TropsCapCmd, '_add_file_in_git_repo', fake_add, raising=True)
+
+	tcc = _make_capcmd(monkeypatch, tmp_path)
+	rv = tcc._add_tee_output_file(['echo', 'hi', '|', 'ttee', '-a', '/tmp/out.txt'])
+
+	assert rv is True
+	assert captured['first_line_comment'] is None
+
+
+def test_ttee_with_long_append_skips_prepend(monkeypatch, tmp_path):
+	"""`cmd | ttee --append path` skips the prepend (append mode) (#162)."""
+	captured = {}
+
+	def fake_add(self, executed_cmd, start_index, first_line_comment=None):
+		captured['first_line_comment'] = first_line_comment
+
+	monkeypatch.setattr(TropsCapCmd, '_add_file_in_git_repo', fake_add, raising=True)
+
+	tcc = _make_capcmd(monkeypatch, tmp_path)
+	rv = tcc._add_tee_output_file(['echo', 'hi', '|', 'ttee', '--append', '/tmp/out.txt'])
+
+	assert rv is True
+	assert captured['first_line_comment'] is None
+
+
+def test_ttee_multifile_collects_all_paths_and_prepends(monkeypatch, tmp_path):
+	"""`cmd | ttee a b c` passes all three paths to _add_file_in_git_repo and supplies the comment (#162)."""
+	captured = {}
+
+	def fake_add(self, executed_cmd, start_index, first_line_comment=None):
+		captured['paths'] = executed_cmd[start_index:]
+		captured['first_line_comment'] = first_line_comment
+
+	monkeypatch.setattr(TropsCapCmd, '_add_file_in_git_repo', fake_add, raising=True)
+
+	tcc = _make_capcmd(monkeypatch, tmp_path)
+	rv = tcc._add_tee_output_file(
+		['echo', 'hi', '|', 'ttee', '/tmp/a', '/tmp/b', '/tmp/c'])
+
+	assert rv is True
+	assert captured['paths'] == ['/tmp/a', '/tmp/b', '/tmp/c']
+	assert captured['first_line_comment'] == '# echo hi'
+
+
+def test_sudo_ttee_is_not_detected(monkeypatch, tmp_path):
+	"""`cmd | sudo ttee path` is out of scope for #162 (tracked in #170); detector returns False."""
+	called = {'add': False}
+
+	def fake_add(self, executed_cmd, start_index, first_line_comment=None):
+		called['add'] = True
+
+	monkeypatch.setattr(TropsCapCmd, '_add_file_in_git_repo', fake_add, raising=True)
+
+	tcc = _make_capcmd(monkeypatch, tmp_path)
+	rv = tcc._add_tee_output_file(['echo', 'hi', '|', 'sudo', 'ttee', '/etc/foo'])
+
+	assert rv is False
+	assert called['add'] is False


### PR DESCRIPTION
## Summary

Closes #162. Implements the intentional behavior swap between ``tee`` and ``ttee`` in ``capture-cmd``'s pipeline detector:

- ``cmd | tee out`` -- still detected and committed, but the file is **not mutated**. Removes a footgun where the previous ``# <cmd>`` implicit prepend silently rewrote any file the user piped into (including JSON, YAML, and binary blobs via the ``errors='ignore'`` read-rewrite path).
- ``cmd | ttee out`` (using the ``ttee`` alias already declared in ``trops init`` for bash and zsh) -- committed **and** ``# <left-command>`` is prepended as the first line. Explicit opt-in for "record the originating command inside the artifact."
- ``cmd | ttee -a out`` / ``cmd | ttee --append out`` -- committed but the prepend is skipped, so growing append logs are not silently rewritten at their head.
- ``cmd | ttee a b c`` -- every existing path is committed; each gets the prepend.
- ``cmd | sudo (t)tee path`` -- still undetected. Parsing sudo's option surface is its own can of worms; tracked in #170.

## Behavior matrix

| Command | Before this PR | After this PR |
|---|---|---|
| ``cmd \| tee out.txt`` | committed; ``# cmd`` silently prepended | committed; **no mutation** |
| ``cmd \| ttee out.txt`` | not detected (silently dropped) | committed; ``# cmd`` prepended |
| ``cmd \| ttee -a out.txt`` | not detected | committed; **no prepend** (append mode) |
| ``cmd \| ttee a b c`` | not detected | all three committed; each prepended |
| ``cmd \| sudo (t)tee path`` | not detected | not detected (see #170) |

## Implementation

In ``src/trops/capcmd.py:_add_tee_output_file`` (lines 278–333):

1. The detector now matches both ``tee`` and ``ttee`` after the last pipe, capturing which word matched.
2. After detection, the function inspects the args after the matched word for ``-a`` / ``--append``. The comment-prepend is supplied to ``_add_file_in_git_repo`` only when ``tee_word == 'ttee'`` and append mode is not detected.
3. Non-path flag args (``-a``, ``--output-error=warn``, etc.) remain harmless: ``_add_file_in_git_repo`` filters them out via ``os.path.isfile``.

## Tests

Six new cases in ``tests/test_capcmd.py``, all unit-level (mock ``_add_file_in_git_repo`` to capture call args; no git fixture needed):

- ``test_tee_does_not_prepend_comment`` -- plain ``tee`` passes ``first_line_comment=None``.
- ``test_ttee_prepends_left_command`` -- ``ttee`` passes ``first_line_comment="# echo hi"``.
- ``test_ttee_with_short_append_skips_prepend`` -- ``ttee -a`` skips the prepend.
- ``test_ttee_with_long_append_skips_prepend`` -- ``ttee --append`` skips the prepend.
- ``test_ttee_multifile_collects_all_paths_and_prepends`` -- multi-file paths are all forwarded; comment is set.
- ``test_sudo_ttee_is_not_detected`` -- detector returns ``False`` (covered by #170).

## Test plan

- [x] ``pytest tests/`` -- 70 passed (previously 64; +6 new).
- [x] ``pytest tests/test_capcmd.py -v`` -- all 15 capcmd tests pass.

## Backward-compat note (called out in CHANGELOG)

Anyone whose current workflow relied on plain ``tee`` implicitly prepending ``# <cmd>`` should switch to ``ttee``. Existing files already committed in env git repos are unaffected -- only newly-written files take the new semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)